### PR TITLE
Added fetch before tag checkout

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+git fetch
+
 git -c advice.detachedHead=false checkout tags/"$PROJECT_TAG"
 
 python $SCRIPT_DIR/deploy.py


### PR DESCRIPTION
When `git -c advice.detachedHead=false checkout tags/"$PROJECT_TAG"` is called on deployment in GitHub, the following error is thrown:

```
error: pathspec 'tags/5.0' did not match any file(s) known to git
```

The general advice on the internet is that you should do a `git fetch` first so you know all the tag have been pulled, then the tag checkout should work.