### PR TITLE
Connector templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,31 @@ docker run -it --rm \
           bp3global/wm-extract-deploy deploy
 ```
 
+# Deploy Templates
+This will deploy connector templates from the current directory and its subdirectories into the Web Modeler instance.
+
+For SaaS environments:
+```shell
+docker run -it --rm \
+    --mount type=bind,src=${PWD},dst=/local --workdir /local \
+      -e CAMUNDA_WM_CLIENT_ID="<Client Id>" \
+      -e CAMUNDA_WM_CLIENT_SECRET="<Client secret>" \
+      -e CAMUNDA_WM_PROJECT="<The WM project to deploy the templates to>" \
+          bp3global/wm-extract-deploy deploy templates
+```
+
+For Self managed environments:
+```shell
+docker run -it --rm \
+    --mount type=bind,src=${PWD},dst=/local --workdir /local \
+      -e CAMUNDA_WM_CLIENT_ID="<Client Id>" \
+      -e CAMUNDA_WM_CLIENT_SECRET="<Client secret>" \
+      -e CAMUNDA_WM_PROJECT="<The WM project to deploy the templates to>" \
+      -e CAMUNDA_WM_HOST="<Web Modeller hostname>" \
+      -e CAMUNDA_WM_AUTH="<Keycloak hostname, if different to the WM_HOST>" \
+          bp3global/wm-extract-deploy deploy templates
+```
+
 # Supported Environment Variables
 
 | EnvVar                   | Description                                                                                                    | Optional?                                                                                                                       |
@@ -172,4 +197,4 @@ You now need to create a client app and secret for the extract-deploy app to use
 1. Open Identity in your browser (`https://<your IP address>:8084`) and log in.
 2. Click `Add Application`, enter a name (this will be the Client ID), and select the `M2M` radio button, then click `Add`.
 3. Click on the new Application you created and make a note of the Client secret as you will need this for the extract script.
-4. Open the `Access to APIs` tab, click the `Assign Permissions` button and then select `Web Modeler API` from the dropdown. Select the read permissions checkbox and then click the `Add` button.
+4. Open the `Access to APIs` tab, click the `Assign Permissions` button and then select `Web Modeler API` from the dropdown. Select the read, write, and create permission checkboxes and then click the `Add` button.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extract and Deploy process models from Web Modeler
 ## Background
-Web Modeler does not currently have support for the extraction and deployment of resources (i.e. BPMN and DMN models and Forms) to different CI / CD platforms such as GitLab, Github and Bitbucket -
+Web Modeler does not currently have support for the extraction and deployment of resources (i.e. BPMN and DMN models and Forms) to different CI / CD platforms such as GitLab, GitHub and Bitbucket -
 this must be managed by the user through the [WM API](https://docs.camunda.io/docs/apis-tools/web-modeler-api/overview/).
 The Web Modeler currently only has
 * An option to deploy models directly to a Zeebe cluster (subject to the user having the right roles assigned)
@@ -116,6 +116,21 @@ docker run -it --rm \
           bp3global/wm-extract-deploy deploy templates
 ```
 
+# Web Modeler project configuration
+
+We support a couple of methods of specifying which Web Modeler project to interact with, either via the `CAMUNDA_WM_PROJECT` environment variable, or by providing a configuration file in the working directory/repository.
+
+The configuration file can be either YAML or JSON and by default we will look for a file named `config.[yml|yaml|json]` in the working directory. If you wish to use an alternate name then this can be specified in the `WM_PROJECT_METADATA_FILE` environment variable. If a config file is not detected then one will be created after the first successful execution. 
+
+The config file should contain a project element with a child id element where the value is the id of the project in Web Modeler (the guid in the URL when accessing the project), and optionally a name property.
+
+e.g. in YAML:
+```yaml
+project:
+  id: 571c8e5d-dcdf-41b5-bb42-e5f3ae593db9
+  name: Connector Templates
+```
+
 # Supported Environment Variables
 
 | EnvVar                   | Description                                                                                                    | Optional?                                                                                                                       |
@@ -140,7 +155,7 @@ docker run -it --rm \
 | CICD_SERVER_HOST         | The GitLab server host                                                                                         | Optional for "extract" operation. For on-premise GitLab, otherwise defaults to "gitlab.com"                                     |
 | PROJECT_TAG              | The label given to the tags created and also the tag that is checked out and deploy                            | Required for "deploy" operation                                                                                                 |
 | SKIP_CI                  | Indicates if upon commit, we do or do not want any pipelines to be executed. The options are "true" or "false" | Required for "extract" operation                                                                                                |
-| WM_PROJECT_METADATA_FILE | The name of the web modeller project configuration file                                                        | Optional for "extract" operation (default = `config.yml` for saving, `config.yml/yaml/json` for reading)                        |
+| WM_PROJECT_METADATA_FILE | The name of the web modeller project configuration file                                                        | Optional for operations involving web modeler (default = `config.yml` if none present, will look for`config.yml/yaml/json`)     |
 | ZEEBE_CLIENT_ID          | The client Id of the Zeebe client credentials                                                                  | Required for "deploy" operation                                                                                                 |
 | ZEEBE_CLIENT_SECRET      | The client secret of the Zeebe client credentials                                                              | Required for "deploy" operation                                                                                                 |
 
@@ -179,8 +194,8 @@ task: <Task pending name='Task-2' coro=<UnaryUnaryCall._invoke() running at /usr
 sys:1: RuntimeWarning: coroutine 'UnaryUnaryCall._invoke' was never awaited
 ```
 
-# Using a local Zebee docker stack for development
-If you are running the extract/deploy app on the same host as the Zebee docker stack (i.e. on a developer's computer) you need to make some changes to the Docker compose file for the Zeebe stack in order for the authentication to work between the local containers.
+# Using a local Zeebe docker stack for development
+If you are running the extract/deploy app on the same host as the Zeebe docker stack (i.e. on a developer's computer) you need to make some changes to the Docker compose file for the Zeebe stack in order for the authentication to work between the local containers.
 
 Assuming that you are using the docker compose files from [this repo](https://github.com/camunda/camunda-platform); In the directory with the Camunda 8 docker-compose file you should edit the `.env` file and change the `HOST` variable from `localhost` to your hosts IP address.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -it --rm \
 ```
 
 # Deploy Templates
-This will deploy connector templates from the current directory and its subdirectories into the Web Modeler instance.
+This will deploy connector templates from the current repo/directory and its subdirectories into the Web Modeler instance, and then commit the configuration file to the repository.
 
 For SaaS environments:
 ```shell
@@ -101,6 +101,12 @@ docker run -it --rm \
       -e CAMUNDA_WM_CLIENT_ID="<Client Id>" \
       -e CAMUNDA_WM_CLIENT_SECRET="<Client secret>" \
       -e CAMUNDA_WM_PROJECT="<The WM project to deploy the templates to>" \
+      -e GIT_USERNAME="<Git Username>" \
+      -e GIT_USER_EMAIL="<Git Email address>" \
+      -e SKIP_CI="<Indicate (\"true\" | \"false\") if you want to run any pipelines or not on the commit>" \
+      -e CICD_PLATFORM="Indicate which SCM platform is being used, such as \"gitlab\", \"github\" or \"bitbucket\"" \
+      -e CICD_SERVER_HOST="<The host of the GIT server. Only needed if using GitLab>" \
+      -e CICD_ACCESS_TOKEN="<CI platform access token>" \
           bp3global/wm-extract-deploy deploy templates
 ```
 
@@ -113,6 +119,12 @@ docker run -it --rm \
       -e CAMUNDA_WM_PROJECT="<The WM project to deploy the templates to>" \
       -e CAMUNDA_WM_HOST="<Web Modeller hostname>" \
       -e CAMUNDA_WM_AUTH="<Keycloak hostname, if different to the WM_HOST>" \
+      -e GIT_USERNAME="<Git Username>" \
+      -e GIT_USER_EMAIL="<Git Email address>" \
+      -e SKIP_CI="<Indicate (\"true\" | \"false\") if you want to run any pipelines or not on the commit>" \
+      -e CICD_PLATFORM="Indicate which SCM platform is being used, such as \"gitlab\", \"github\" or \"bitbucket\"" \
+      -e CICD_SERVER_HOST="<The host of the GIT server. Only needed if using GitLab>" \
+      -e CICD_ACCESS_TOKEN="<CI platform access token>" \
           bp3global/wm-extract-deploy deploy templates
 ```
 

--- a/python/deployConnectorTemplates.py
+++ b/python/deployConnectorTemplates.py
@@ -10,7 +10,7 @@
 #
 ############################################################################
 
-import webModeller
+import webModeler
 import env
 import os
 import glob
@@ -23,7 +23,7 @@ class deployTemplates:
 
     def __init__(self):
         self.env = env.Environment()
-        self.wm = webModeller.webModeller()
+        self.wm = webModeler.webModeler()
         self.wm.setWMHost(self.wmHost)
         self.checkEnv()
 

--- a/python/deployConnectorTemplates.py
+++ b/python/deployConnectorTemplates.py
@@ -1,0 +1,86 @@
+import webModeller
+import env
+import os
+import glob
+import json
+
+class deployTemplates:
+    wmHost = 'cloud.camunda.io'
+    grantType = 'client_credentials'
+    protocol = 'https'
+
+    def __init__(self):
+        self.env = env.Environment()
+        self.wm = webModeller.webModeller()
+        self.wm.setWMHost(self.wmHost)
+        self.checkEnv()
+
+    # Just for debug for now
+    def checkEnv(self):
+        self.env.checkEnvVar('CAMUNDA_WM_HOST', False)
+        self.env.checkEnvVar('CAMUNDA_WM_AUTH', False)
+        self.env.checkEnvVar('CAMUNDA_WM_SSL', False)
+        self.env.checkEnvVar('CAMUNDA_WM_CLIENT_ID', False)
+        self.env.checkEnvVar('CAMUNDA_WM_CLIENT_SECRET')
+        self.env.checkEnvVar('MODEL_PATH', False)
+
+if __name__ == "__main__":
+    deployTemplates = deployTemplates()
+    projectRef = None
+
+    # Optional EnvVars
+    try:
+        if os.environ["CAMUNDA_WM_PROJECT"] is not None and os.environ["CAMUNDA_WM_PROJECT"] != "":
+            projectRef = os.environ['CAMUNDA_WM_PROJECT']
+    except KeyError:
+        pass
+
+    deployTemplates.wm.configure()
+    deployTemplates.wm.authenticate()
+    projectId = deployTemplates.wm.getProject(projectRef)['items'][0]['id']
+
+    templates = glob.glob("./**/*.json", recursive=True)
+    print("Found templates:", templates)
+
+    for template in templates:
+        with open(template, 'r') as file:
+            print("Uploading template", template)
+
+            filetype = file.name.split(".")[-1]
+            if filetype not in ["bpmn", "dmn", "form", "json"]:
+                raise ValueError("Unsupported filetype in", file.name)
+
+            content = json.load(file)
+
+            if filetype == "json":
+                name = content["name"]
+                filetype = "connector_template"
+            else:
+                name = file.name.split(".")[-2].split("/")[-1]
+
+            # Check if file already exists in the project
+            fileSearch = deployTemplates.wm.searchFiles(projectId, name)
+
+            if len(fileSearch["items"]) > 0:
+                fileId = fileSearch["items"][0]["id"]
+                # We need to use the ID and schema from the existing file in WM
+                existingContent = json.loads(deployTemplates.wm.getFileById(fileId)["content"])
+                content["id"] = existingContent["id"]
+                content["$schema"] = existingContent["$schema"]
+
+                deployTemplates.wm.updateFile(
+                    projectId=projectId,
+                    fileId=fileId,
+                    name=name,
+                    filetype=filetype,
+                    content=json.dumps(content),
+                    revision=fileSearch["items"][0]["revision"]
+                )
+            else:
+                deployTemplates.wm.postFile(
+                    projectId=projectId,
+                    name=name,
+                    filetype=filetype,
+                    content=json.dumps(content)
+                )
+            file.close()

--- a/python/deployConnectorTemplates.py
+++ b/python/deployConnectorTemplates.py
@@ -1,3 +1,15 @@
+############################################################################
+#
+# Licensed Materials - Property of BP3
+#
+# Web Modeler Extract Deploy (WMED)
+#
+# Copyright © BP3 Global Inc. 2024. All Rights Reserved.
+# This software is subject to copyright protection under
+# the laws of the United States and other countries.
+#
+############################################################################
+
 import webModeller
 import env
 import os
@@ -44,7 +56,7 @@ if __name__ == "__main__":
 
     for template in templates:
         with open(template, 'r') as file:
-            print("Uploading template", template)
+            print("Processing template", template)
 
             filetype = file.name.split(".")[-1]
             if filetype not in ["bpmn", "dmn", "form", "json"]:
@@ -67,15 +79,17 @@ if __name__ == "__main__":
                 existingContent = json.loads(deployTemplates.wm.getFileById(fileId)["content"])
                 content["id"] = existingContent["id"]
                 content["$schema"] = existingContent["$schema"]
+                content["version"] = existingContent["version"]
 
-                deployTemplates.wm.updateFile(
-                    projectId=projectId,
-                    fileId=fileId,
-                    name=name,
-                    filetype=filetype,
-                    content=json.dumps(content),
-                    revision=fileSearch["items"][0]["revision"]
-                )
+                if content != existingContent:
+                    deployTemplates.wm.updateFile(
+                        projectId=projectId,
+                        fileId=fileId,
+                        name=name,
+                        filetype=filetype,
+                        content=json.dumps(content),
+                        revision=fileSearch["items"][0]["revision"]
+                    )
             else:
                 deployTemplates.wm.postFile(
                     projectId=projectId,

--- a/python/extract.py
+++ b/python/extract.py
@@ -11,10 +11,8 @@
 ############################################################################
 
 import os
-import json
-import yaml
-import requests
 import env
+import webModeller
 
 class Extraction:
 
@@ -27,7 +25,8 @@ class Extraction:
 
     def __init__(self):
         self.env = env.Environment()
-        self.setWMHost(self.wmHost)
+        self.wm = webModeller.webModeller()
+        self.wm.setWMHost(self.wmHost)
         self.checkEnv()
 
     # Just for debug for now
@@ -38,230 +37,6 @@ class Extraction:
         self.env.checkEnvVar('CAMUNDA_WM_CLIENT_ID', False)
         self.env.checkEnvVar('CAMUNDA_WM_CLIENT_SECRET')
         self.env.checkEnvVar('MODEL_PATH', False)
-
-    def setWMHost(self, wmHost):
-        self.wmHost = wmHost
-        self.audience = 'api.' + wmHost
-        if wmHost == self.SAAS_HOST:
-            self.authURL = self.protocol + '://login.' + wmHost + '/oauth/token'
-            self.wmAPIURL = self.protocol + '://modeler.' + wmHost + '/api'
-        else:
-            self.authURL = self.setAuthHost(wmHost)
-            self.wmAPIURL = self.protocol + '://' + wmHost + '/api'
-
-    def setAuthHost(self, authHost):
-        self.authURL = self.protocol + '://' + authHost + '/auth/realms/camunda-platform/protocol/openid-connect/token'
-
-    def setClientId(self, id):
-        self.clientId = id
-
-    def setClientSecret(self, secret):
-        self.clientSecret = secret
-
-    def getAuthURL(self):
-        return self.authURL
-
-    def getWMAPIURL(self, version=1):
-        return '{}/v{}'.format(self.wmAPIURL, version)
-
-    def setHeaders(self):
-        return {
-            "Authorization": "Bearer {}".format(self.accessToken),
-            "Content-Type": "application/json"
-        }
-
-    def getProtocol(self):
-        return self.protocol
-
-    def setProtocol(self, protocol):
-        self.protocol = protocol
-
-    def setConfigFile(self, filename):
-        self.configFile = filename
-
-    def getConfigFile(self):
-        return self.configFile
-
-    # Authenticate to Camunda Web Modeler and get an access token
-    def authenticate(self):
-
-        response = requests.post(self.getAuthURL(), data={
-            "client_id": self.clientId,
-            "client_secret": self.clientSecret,
-            "audience": self.audience,
-            "grant_type": self.grantType
-        })
-
-        print("Authentication response", response.status_code)
-
-        self.accessToken = response.json()["access_token"]
-        return self.accessToken
-
-    def createReferenceFile(self, configFile, data):
-        if not os.path.exists(configFile):
-            with open(configFile, "w") as file:
-                if configFile.endswith("yml") or configFile.endswith("yaml"):
-                    file.write(yaml.dump(data))
-                elif configFile.endswith("json"):
-                    file.write(json.dumps(data))
-                file.close()
-
-    def parseYamlConfig(self, file):
-        yamlConfig = yaml.safe_load(file)
-        print("Loaded YAML config:", yamlConfig)
-        return yamlConfig
-
-    def parseJsonConfig(self, file):
-        jsonConfig = json.load(file)
-        print("Loaded JSON config:", jsonConfig)
-        return jsonConfig
-
-    def loadProjectConfig(self):
-        # We may want to make the following changes in the future:
-        # - Pass in the file name using an env var, e.g. WM_PROJECT_METADATA_FILE
-        # Specify if the file should be JSON or YAML, so it can contain other metadata items
-
-        # This will look for (in order)
-        #
-        #   1. config.yml/yaml
-        #   2. config.json
-        #   3. wm-project-id - I can see this being dropped in the future
-        #
-        #   config.yml
-        #   ----------
-        #   project:
-        #     id: <UUID>
-        #     name:                       # Optional extension
-        #
-        #   config.json
-        #   -----------
-        #   {
-        #     "project": {
-        #       "id": "<UUID>",
-        #       "name": "<project name>"    # Optional extension
-        #      }
-        #   }
-        #
-        #   wm-project-id
-        #   -------------
-        #   <UUID>
-
-        projectConfigFiles=[self.configFile, "config.yaml", "config.json", "wm-project-id"]
-
-        for configFile in projectConfigFiles:
-            # Check to see if one of the config file options exists
-            # If it does then read the configuration from it
-            if not hasattr(self, "configDict") and os.path.exists(configFile):
-                with open(configFile, 'r') as file:
-                    if configFile.endswith("yml") or configFile.endswith("yaml"):
-                        self.configDict = self.parseYamlConfig(file)
-                        self.configFile = configFile
-                    elif configFile.endswith("json"):
-                        self.configDict = self.parseJsonConfig(file)
-                        self.configFile = configFile
-                    else:
-                        self.configDict = {"project": {"id": file.read().strip()}}
-                        self.configFile = configFile
-
-    def getProject(self, projectRef):
-
-        project = None
-        needsConfigFile = False
-        self.loadProjectConfig()
-
-        # If we loaded a config, search for the provided ID
-        if hasattr(self, "configDict") and self.configDict is not None:
-            projectId = self.configDict["project"]["id"]
-            project = self.searchProject("id", projectId)
-            if project == None or not project['items']:
-                print("Project not found using project ID {} from {}".format(projectId, self.configFile))
-                project = None
-                needsConfigFile = True
-            elif self.configFile == "wm-project-id":
-                needsConfigFile = True
-                self.configFile = "config.yml"
-
-        # If we failed to find the configured project, or there was no config supplied then try looking it up by
-        # the projectRef we were given
-        if project is None:
-            needsConfigFile = True
-            # It could be we were given the Id
-            print("projectRef = '{}'".format(projectRef))
-            if projectRef is not None and projectRef != "":
-                project = self.searchProject("id", projectRef)
-                # If there are no 'items' then try looking up the project by name
-                if project is not None and not project['items']:
-                    project = self.searchProject("name", projectRef)
-                    if not project["items"] and projectRef is not None:
-                        print("Project '{}' not found".format(projectRef))
-            else:
-                raise ValueError("Either a valid config file or 'CAMUNDA_WM_PROJECT' environment variable must be "
-                                 "supplied.")
-
-        if not project["items"]:
-            raise ValueError("Web Modeler project not found")
-
-        if needsConfigFile:
-            data = {
-                "project": {
-                    "id": project['items'][0]['id'],
-                    "name": project["items"][0]["name"]
-                }
-            }
-            self.createReferenceFile(self.configFile, data)
-
-        return project
-
-    def searchProject(self, key, name):
-        body = {
-            "filter": {
-                key: name
-            },
-            "sort": [{
-                "field": "created",
-                "direction": "ASC"
-            }]
-        }
-
-        response = requests.post(
-            self.getWMAPIURL() + '/projects/search',
-            json=body,
-            headers=self.setHeaders()
-        )
-
-        # print("Find project response", response.status_code)
-        self.project = response.json()
-        return self.project
-
-    def searchFiles(self, id):
-        body = {
-            "filter": {
-                "projectId": id
-            },
-            "sort": [{
-                "field": "created",
-                "direction": "ASC"
-            }]
-        }
-
-        response = requests.post(
-            self.getWMAPIURL() + '/files/search',
-            json=body,
-            headers=self.setHeaders()
-        )
-
-        # print("Find project files response", response.status_code)
-        return response.json()
-
-    def getFileById(self, id):
-
-        response = requests.get(
-            self.getWMAPIURL() + "/files/" + id,
-            headers=self.setHeaders()
-        )
-
-        # print("Retrieve file content response", response.status_code)
-        return response.json()
 
     def getModelPath(self):
         return self.env.getModelPath()
@@ -280,19 +55,16 @@ class Extraction:
             if(item["canonicalPath"] is not None and item["canonicalPath"]):
                 os.makedirs(os.path.dirname(file_path), exist_ok=True)
 
-            data = self.getFileById(item["id"])["content"]
+            data = self.wm.getFileById(item["id"])["content"]
             # print(item)
             with open(file_path, "w") as file:
                 file.write(data)
                 file.close()
 
+
 if __name__ == "__main__":
     extract = Extraction()
     projectRef = None
-
-    # Required EnvVars
-    extract.setClientId(os.environ["CAMUNDA_WM_CLIENT_ID"])
-    extract.setClientSecret(os.environ['CAMUNDA_WM_CLIENT_SECRET'])
 
     modelPath = os.environ["MODEL_PATH"]
     extract.setModelPath(modelPath)
@@ -300,39 +72,15 @@ if __name__ == "__main__":
 
     # Optional EnvVars
     try:
-        if os.environ["CAMUNDA_WM_SSL"] != None and os.environ["CAMUNDA_WM_SSL"] != "":
-            if os.environ["CAMUNDA_WM_SSL"].lower() == "false":
-                extract.setProtocol('http')
-    except KeyError:
-        pass
-
-    try:
-        if os.environ["CAMUNDA_WM_HOST"] != None and os.environ["CAMUNDA_WM_HOST"] != "":
-            extract.setWMHost(os.environ["CAMUNDA_WM_HOST"])
-    except KeyError:
-        pass
-
-    try:
-        if os.environ["CAMUNDA_WM_AUTH"] != None and os.environ["CAMUNDA_WM_AUTH"] != "":
-            extract.setAuthHost(os.environ["CAMUNDA_WM_AUTH"])
-    except KeyError:
-        pass
-
-    try:
-        if os.environ["CAMUNDA_WM_PROJECT"] != None and os.environ["CAMUNDA_WM_PROJECT"] != "":
+        if os.environ["CAMUNDA_WM_PROJECT"] is not None and os.environ["CAMUNDA_WM_PROJECT"] != "":
             projectRef = os.environ['CAMUNDA_WM_PROJECT']
     except KeyError:
         pass
 
-    try:
-        if os.environ["WM_PROJECT_METADATA_FILE"] != None and os.environ["WM_PROJECT_METADATA_FILE"] != "":
-            extract.setConfigFile(os.environ["WM_PROJECT_METADATA_FILE"])
-    except KeyError:
-        pass
+    extract.wm.configure()
+    extract.wm.authenticate()
 
-    extract.authenticate()
-
-    project = extract.getProject(projectRef)
-    items = extract.searchFiles(project["items"][0]["id"])
+    project = extract.wm.getProject(projectRef)
+    items = extract.wm.searchFiles(project["items"][0]["id"])
 
     extract.extract(modelPath, items)

--- a/python/extract.py
+++ b/python/extract.py
@@ -12,7 +12,7 @@
 
 import os
 import env
-import webModeller
+import webModeler
 
 class Extraction:
 
@@ -25,7 +25,7 @@ class Extraction:
 
     def __init__(self):
         self.env = env.Environment()
-        self.wm = webModeller.webModeller()
+        self.wm = webModeler.webModeler()
         self.wm.setWMHost(self.wmHost)
         self.checkEnv()
 

--- a/python/webModeler.py
+++ b/python/webModeler.py
@@ -102,9 +102,9 @@ class webModeler:
             headers=self.getHeaders()
         )
 
-        print("Find project response", response.status_code)
+        #print("Find project response", response.status_code)
         self.project = response.json()
-        #TODO: Add error handling
+
         return self.project
 
     def searchFiles(self, id, name=None):
@@ -267,10 +267,9 @@ class webModeler:
             headers=self.getHeaders()
         )
 
-        #TODO: Improve exception handling
         print("PostFile response", response.status_code)
         if response.status_code != 200:
-            print("Error Details", response.json())
+            raise RuntimeError("Attempt to create file failed.", response.json())
         else:
             return response.json()
 
@@ -290,10 +289,9 @@ class webModeler:
             headers=self.getHeaders()
         )
 
-        #TODO: Improve exception handling
         print("UpdateFile response", response.status_code)
         if response.status_code != 200:
-            print("Error Details", response.json())
+            raise RuntimeError("Attempt to update file failed.", response.json())
         else:
             return response.json()
 
@@ -309,9 +307,8 @@ class webModeler:
             headers=self.getHeaders()
         )
 
-        #TODO: Improve exception handling
         print("CreateMilestone response", response.status_code)
         if response.status_code != 200:
-            print("Error Details", response.json())
+            raise RuntimeError("Attempt to create milestone failed.", response.json())
         else:
             return response.json()

--- a/python/webModeler.py
+++ b/python/webModeler.py
@@ -15,7 +15,7 @@ import os
 import json
 import yaml
 
-class webModeller:
+class webModeler:
     # In the future we may need to override for Self Managed if the authentication mechanism is different
     SAAS_HOST = 'cloud.camunda.io'
     wmHost = 'cloud.camunda.io'

--- a/python/webModeler.py
+++ b/python/webModeler.py
@@ -191,36 +191,8 @@ class webModeler:
         return jsonConfig
 
     def loadProjectConfig(self):
-        # We may want to make the following changes in the future:
-        # - Pass in the file name using an env var, e.g. WM_PROJECT_METADATA_FILE
-        # Specify if the file should be JSON or YAML, so it can contain other metadata items
 
-        # This will look for (in order)
-        #
-        #   1. config.yml/yaml
-        #   2. config.json
-        #   3. wm-project-id - I can see this being dropped in the future
-        #
-        #   config.yml
-        #   ----------
-        #   project:
-        #     id: <UUID>
-        #     name:                       # Optional extension
-        #
-        #   config.json
-        #   -----------
-        #   {
-        #     "project": {
-        #       "id": "<UUID>",
-        #       "name": "<project name>"    # Optional extension
-        #      }
-        #   }
-        #
-        #   wm-project-id
-        #   -------------
-        #   <UUID>
-
-        projectConfigFiles=[self.configFile, "config.yaml", "config.json", "wm-project-id"]
+        projectConfigFiles=[self.configFile, "config.yaml", "config.json"]
 
         for configFile in projectConfigFiles:
             # Check to see if one of the config file options exists
@@ -232,9 +204,6 @@ class webModeler:
                         self.configFile = configFile
                     elif configFile.endswith("json"):
                         self.configDict = self.parseJsonConfig(file)
-                        self.configFile = configFile
-                    else:
-                        self.configDict = {"project": {"id": file.read().strip()}}
                         self.configFile = configFile
 
     def getProject(self, projectRef):
@@ -251,9 +220,6 @@ class webModeler:
                 print("Project not found using project ID {} from {}".format(projectId, self.configFile))
                 project = None
                 needsConfigFile = True
-            elif self.configFile == "wm-project-id":
-                needsConfigFile = True
-                self.configFile = "config.yml"
 
         # If we failed to find the configured project, or there was no config supplied then try looking it up by
         # the projectRef we were given

--- a/python/webModeller.py
+++ b/python/webModeller.py
@@ -1,0 +1,271 @@
+import requests
+import os
+import json
+import yaml
+
+class webModeller:
+    # In the future we may need to override for Self Managed if the authentication mechanism is different
+    SAAS_HOST = 'cloud.camunda.io'
+    wmHost = 'cloud.camunda.io'
+    grantType = 'client_credentials'
+    protocol = 'https'
+    configFile = 'config.yml'
+
+    def __init__(self):
+        # self.env = env.Environment()
+        self.setWMHost(self.wmHost)
+
+    def setWMHost(self, wmHost):
+        self.wmHost = wmHost
+        self.audience = 'api.' + wmHost
+        if wmHost == self.SAAS_HOST:
+            self.authURL = self.protocol + '://login.' + wmHost + '/oauth/token'
+            self.wmAPIURL = self.protocol + '://modeler.' + wmHost + '/api'
+        else:
+            self.authURL = self.setAuthHost(wmHost)
+            self.wmAPIURL = self.protocol + '://' + wmHost + '/api'
+
+    def setAuthHost(self, authHost):
+        self.authURL = self.protocol + '://' + authHost + '/auth/realms/camunda-platform/protocol/openid-connect/token'
+
+    def setClientId(self, id):
+        self.clientId = id
+
+    def setClientSecret(self, secret):
+        self.clientSecret = secret
+
+    def getAuthURL(self):
+        return self.authURL
+
+    def getWMAPIURL(self, version=1):
+        return '{}/v{}'.format(self.wmAPIURL, version)
+
+    def setConfigFile(self, filename):
+        self.configFile = filename
+
+    def getConfigFile(self):
+        return self.configFile
+
+    def getProtocol(self):
+        return self.protocol
+
+    def setProtocol(self, protocol):
+        self.protocol = protocol
+
+    def getHeaders(self):
+        return {
+            "Authorization": "Bearer {}".format(self.accessToken),
+            "Content-Type": "application/json"
+        }
+
+    # Authenticate to Camunda Web Modeler and get an access token
+    def authenticate(self):
+
+        response = requests.post(self.getAuthURL(), data={
+            "client_id": self.clientId,
+            "client_secret": self.clientSecret,
+            "audience": self.audience,
+            "grant_type": self.grantType
+        })
+
+        print("Authentication response", response.status_code)
+
+        self.accessToken = response.json()["access_token"]
+        return self.accessToken
+
+    def searchProject(self, key, name):
+        body = {
+            "filter": {
+                key: name
+            },
+            "sort": [{
+                "field": "created",
+                "direction": "ASC"
+            }]
+        }
+
+        response = requests.post(
+            self.getWMAPIURL() + '/projects/search',
+            json=body,
+            headers=self.getHeaders()
+        )
+
+        # print("Find project response", response.status_code)
+        self.project = response.json()
+        return self.project
+
+    def searchFiles(self, id):
+        body = {
+            "filter": {
+                "projectId": id
+            },
+            "sort": [{
+                "field": "created",
+                "direction": "ASC"
+            }]
+        }
+
+        response = requests.post(
+            self.getWMAPIURL() + '/files/search',
+            json=body,
+            headers=self.getHeaders()
+        )
+
+        # print("Find project files response", response.status_code)
+        return response.json()
+
+    def getFileById(self, id):
+
+        response = requests.get(
+            self.getWMAPIURL() + "/files/" + id,
+            headers=self.getHeaders()
+        )
+
+        # print("Retrieve file content response", response.status_code)
+        return response.json()
+
+    def configure(self):
+        # Required EnvVars
+        self.setClientId(os.environ["CAMUNDA_WM_CLIENT_ID"])
+        self.setClientSecret(os.environ['CAMUNDA_WM_CLIENT_SECRET'])
+
+        # Optional EnvVars
+        try:
+            if os.environ["CAMUNDA_WM_SSL"] is not None and os.environ["CAMUNDA_WM_SSL"] != "":
+                if os.environ["CAMUNDA_WM_SSL"].lower() == "false":
+                    self.setProtocol('http')
+        except KeyError:
+            pass
+
+        try:
+            if os.environ["CAMUNDA_WM_HOST"] is not None and os.environ["CAMUNDA_WM_HOST"] != "":
+                self.setWMHost(os.environ["CAMUNDA_WM_HOST"])
+        except KeyError:
+            pass
+
+        try:
+            if os.environ["CAMUNDA_WM_AUTH"] is not None and os.environ["CAMUNDA_WM_AUTH"] != "":
+                self.setAuthHost(os.environ["CAMUNDA_WM_AUTH"])
+        except KeyError:
+            pass
+
+        try:
+            if os.environ["WM_PROJECT_METADATA_FILE"] != None and os.environ["WM_PROJECT_METADATA_FILE"] != "":
+                self.setConfigFile(os.environ["WM_PROJECT_METADATA_FILE"])
+        except KeyError:
+            pass
+
+    def createReferenceFile(self, configFile, data):
+        if not os.path.exists(configFile):
+            with open(configFile, "w") as file:
+                if configFile.endswith("yml") or configFile.endswith("yaml"):
+                    file.write(yaml.dump(data))
+                elif configFile.endswith("json"):
+                    file.write(json.dumps(data))
+                file.close()
+
+    def parseYamlConfig(self, file):
+        yamlConfig = yaml.safe_load(file)
+        print("Loaded YAML config:", yamlConfig)
+        return yamlConfig
+
+    def parseJsonConfig(self, file):
+        jsonConfig = json.load(file)
+        print("Loaded JSON config:", jsonConfig)
+        return jsonConfig
+
+    def loadProjectConfig(self):
+        # We may want to make the following changes in the future:
+        # - Pass in the file name using an env var, e.g. WM_PROJECT_METADATA_FILE
+        # Specify if the file should be JSON or YAML, so it can contain other metadata items
+
+        # This will look for (in order)
+        #
+        #   1. config.yml/yaml
+        #   2. config.json
+        #   3. wm-project-id - I can see this being dropped in the future
+        #
+        #   config.yml
+        #   ----------
+        #   project:
+        #     id: <UUID>
+        #     name:                       # Optional extension
+        #
+        #   config.json
+        #   -----------
+        #   {
+        #     "project": {
+        #       "id": "<UUID>",
+        #       "name": "<project name>"    # Optional extension
+        #      }
+        #   }
+        #
+        #   wm-project-id
+        #   -------------
+        #   <UUID>
+
+        projectConfigFiles=[self.configFile, "config.yaml", "config.json", "wm-project-id"]
+
+        for configFile in projectConfigFiles:
+            # Check to see if one of the config file options exists
+            # If it does then read the configuration from it
+            if not hasattr(self, "configDict") and os.path.exists(configFile):
+                with open(configFile, 'r') as file:
+                    if configFile.endswith("yml") or configFile.endswith("yaml"):
+                        self.configDict = self.parseYamlConfig(file)
+                        self.configFile = configFile
+                    elif configFile.endswith("json"):
+                        self.configDict = self.parseJsonConfig(file)
+                        self.configFile = configFile
+                    else:
+                        self.configDict = {"project": {"id": file.read().strip()}}
+                        self.configFile = configFile
+
+    def getProject(self, projectRef):
+
+        project = None
+        needsConfigFile = False
+        self.loadProjectConfig()
+
+        # If we loaded a config, search for the provided ID
+        if hasattr(self, "configDict") and self.configDict is not None:
+            projectId = self.configDict["project"]["id"]
+            project = self.searchProject("id", projectId)
+            if project is None or not project['items']:
+                print("Project not found using project ID {} from {}".format(projectId, self.configFile))
+                project = None
+                needsConfigFile = True
+            elif self.configFile == "wm-project-id":
+                needsConfigFile = True
+                self.configFile = "config.yml"
+
+        # If we failed to find the configured project, or there was no config supplied then try looking it up by
+        # the projectRef we were given
+        if project is None:
+            needsConfigFile = True
+            # It could be we were given the Id
+            print("projectRef = '{}'".format(projectRef))
+            if projectRef is not None and projectRef != "":
+                project = self.searchProject("id", projectRef)
+                # If there are no 'items' then try looking up the project by name
+                if project is not None and not project['items']:
+                    project = self.searchProject("name", projectRef)
+                    if not project["items"] and projectRef is not None:
+                        print("Project '{}' not found".format(projectRef))
+            else:
+                raise ValueError("Either a valid config file or 'CAMUNDA_WM_PROJECT' environment variable must be "
+                                 "supplied.")
+
+        if not project["items"]:
+            raise ValueError("Web Modeler project not found")
+
+        if needsConfigFile:
+            data = {
+                "project": {
+                    "id": project['items'][0]['id'],
+                    "name": project["items"][0]["name"]
+                }
+            }
+            self.createReferenceFile(self.configFile, data)
+
+        return project

--- a/python/webModeller.py
+++ b/python/webModeller.py
@@ -102,8 +102,9 @@ class webModeller:
             headers=self.getHeaders()
         )
 
-        # print("Find project response", response.status_code)
+        print("Find project response", response.status_code)
         self.project = response.json()
+        #TODO: Add error handling
         return self.project
 
     def searchFiles(self, id, name=None):
@@ -300,9 +301,12 @@ class webModeller:
             headers=self.getHeaders()
         )
 
+        #TODO: Improve exception handling
         print("PostFile response", response.status_code)
         if response.status_code != 200:
             print("Error Details", response.json())
+        else:
+            return response.json()
 
     def updateFile(self, projectId, fileId, name, filetype, content, revision):
 
@@ -320,6 +324,28 @@ class webModeller:
             headers=self.getHeaders()
         )
 
+        #TODO: Improve exception handling
         print("UpdateFile response", response.status_code)
         if response.status_code != 200:
             print("Error Details", response.json())
+        else:
+            return response.json()
+
+    def createMilestone(self, fileId, name):
+        body = {
+            "name": name,
+            "fileId": fileId
+        }
+
+        response = requests.post(
+            url=self.getWMAPIURL() + "/milestones",
+            json=body,
+            headers=self.getHeaders()
+        )
+
+        #TODO: Improve exception handling
+        print("CreateMilestone response", response.status_code)
+        if response.status_code != 200:
+            print("Error Details", response.json())
+        else:
+            return response.json()

--- a/python/webModeller.py
+++ b/python/webModeller.py
@@ -1,3 +1,15 @@
+############################################################################
+#
+# Licensed Materials - Property of BP3
+#
+# Web Modeler Extract Deploy (WMED)
+#
+# Copyright © BP3 Global Inc. 2024. All Rights Reserved.
+# This software is subject to copyright protection under
+# the laws of the United States and other countries.
+#
+############################################################################
+
 import requests
 import os
 import json

--- a/python/webModeller.py
+++ b/python/webModeller.py
@@ -94,7 +94,7 @@ class webModeller:
         self.project = response.json()
         return self.project
 
-    def searchFiles(self, id):
+    def searchFiles(self, id, name=None):
         body = {
             "filter": {
                 "projectId": id
@@ -104,6 +104,9 @@ class webModeller:
                 "direction": "ASC"
             }]
         }
+
+        if name is not None:
+            body["filter"]["name"] = name
 
         response = requests.post(
             self.getWMAPIURL() + '/files/search',
@@ -269,3 +272,42 @@ class webModeller:
             self.createReferenceFile(self.configFile, data)
 
         return project
+
+    def postFile(self, projectId, name, filetype, content):
+
+        body = {
+            "name": name,
+            "projectId": projectId,
+            "content": content,
+            "fileType": filetype
+        }
+
+        response = requests.post(
+            url=self.getWMAPIURL() + "/files",
+            json=body,
+            headers=self.getHeaders()
+        )
+
+        print("PostFile response", response.status_code)
+        if response.status_code != 200:
+            print("Error Details", response.json())
+
+    def updateFile(self, projectId, fileId, name, filetype, content, revision):
+
+        body = {
+            "name": name,
+            "projectId": projectId,
+            "content": content,
+            "fileType": filetype,
+            "revision": revision
+        }
+
+        response = requests.patch(
+            url=self.getWMAPIURL() + "/files/" + fileId,
+            json=body,
+            headers=self.getHeaders()
+        )
+
+        print("UpdateFile response", response.status_code)
+        if response.status_code != 200:
+            print("Error Details", response.json())

--- a/scripts/deployTemplates.sh
+++ b/scripts/deployTemplates.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+############################################################################
+#
+# Licensed Materials - Property of BP3
+#
+# Web Modeler Extract Deploy (WMED)
+#
+# Copyright © BP3 Global Inc. 2024. All Rights Reserved.
+# This software is subject to copyright protection under
+# the laws of the United States and other countries.
+#
+############################################################################
+
+python $SCRIPT_DIR/deployConnectorTemplates.py

--- a/scripts/deployTemplates.sh
+++ b/scripts/deployTemplates.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ############################################################################
 #
@@ -12,4 +12,46 @@
 #
 ############################################################################
 
+source $SCRIPT_DIR/functions.sh
+
+checkRequiredEnvVar CICD_ACCESS_TOKEN               "$CICD_ACCESS_TOKEN"
+checkRequiredEnvVar CICD_REPOSITORY_PATH            "$CICD_REPOSITORY_PATH"
+
+if [ "$CICD_PLATFORM" = "" ]; then
+  CICD_PLATFORM=gitlab
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="gitlab.com"
+  fi
+elif [ "$CICD_PLATFORM" = "github" ]; then
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="github.com"
+  fi
+elif [ "$CICD_PLATFORM" = "bitbucket" ]; then
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="bitbucket.org"
+  fi
+fi
+echo "The CI/CD platform is: $CICD_PLATFORM"
+
+git config --global user.name "$GIT_USERNAME"
+git config --global user.email $GIT_USER_EMAIL
+
+git fetch
+
+git checkout main
+
 python $SCRIPT_DIR/deployConnectorTemplates.py
+
+git add config.*
+
+# [skip ci] works across all the supported platforms
+if [ "$COMMIT_MSG" = "" ]; then
+  COMMIT_MSG="Updated by Camunda extract-deploy pipeline"
+fi
+if [ "$SKIP_CI" = "" -o "$SKIP_CI" = "true" ]; then
+  COMMIT_MSG="${COMMIT_MSG} [skip ci]"
+fi
+
+git commit -m "${COMMIT_MSG}"
+
+git push "$(getUrl "$CICD_PLATFORM" "$CICD_SERVER_HOST" "$CICD_ACCESS_TOKEN" "$CICD_REPOSITORY_PATH")" $CICD_BRANCH

--- a/scripts/extractDeploy.sh
+++ b/scripts/extractDeploy.sh
@@ -14,6 +14,7 @@
 
 mode_extract=0
 mode_deploy=0
+mode_templates=0
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -21,7 +22,11 @@ while [[ $# -gt 0 ]]; do
           mode_extract=1
             ;;
         deploy)
-          mode_deploy=1
+          if [ $# -gt 1 ] && [ "$2" == "templates" ]; then
+            mode_templates=1
+          else
+            mode_deploy=1
+          fi
             ;;
         *)
           echo "Unknown mode: '$1'"
@@ -53,4 +58,12 @@ if [ $mode_deploy == 1 ]; then
 #  checkRequiredEnvVar PROJECT_TAG                   "$PROJECT_TAG"
 
   $SCRIPT_DIR/deploy.sh
+fi
+
+if [ $mode_templates == 1 ]; then
+  echo "mode = 'deploy templates'"
+#  checkRequiredEnvVar CAMUNDA_WM_CLIENT_ID          "$CAMUNDA_WM_CLIENT_ID"
+#  checkRequiredEnvVar CAMUNDA_WM_CLIENT_SECRET      "$CAMUNDA_WM_CLIENT_SECRET"
+
+  $SCRIPT_DIR/deploy_templates.sh
 fi

--- a/scripts/extractDeploy.sh
+++ b/scripts/extractDeploy.sh
@@ -16,25 +16,22 @@ mode_extract=0
 mode_deploy=0
 mode_templates=0
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        extract)
-          mode_extract=1
-            ;;
-        deploy)
-          if [ $# -gt 1 ] && [ "$2" == "templates" ]; then
-            mode_templates=1
-          else
-            mode_deploy=1
-          fi
-            ;;
-        *)
-          echo "Unknown mode: '$1'"
-          exit 1
-            ;;
-    esac
-    shift
-done
+case "$1" in
+    extract)
+      mode_extract=1
+        ;;
+    deploy)
+      if [ $# -gt 1 ] && [ "$2" == "templates" ]; then
+        mode_templates=1
+      else
+        mode_deploy=1
+      fi
+        ;;
+    *)
+      echo "Unknown mode: '$1'"
+      exit 1
+        ;;
+esac
 
 if [ $mode_extract == 1 ]; then
   echo "mode = 'extract'"
@@ -65,5 +62,5 @@ if [ $mode_templates == 1 ]; then
 #  checkRequiredEnvVar CAMUNDA_WM_CLIENT_ID          "$CAMUNDA_WM_CLIENT_ID"
 #  checkRequiredEnvVar CAMUNDA_WM_CLIENT_SECRET      "$CAMUNDA_WM_CLIENT_SECRET"
 
-  $SCRIPT_DIR/deploy_templates.sh
+  $SCRIPT_DIR/deployTemplates.sh
 fi


### PR DESCRIPTION
@benariss Created a draft PR - just as somewhere to put some documentation for the changes.

Add a new command option for deploying templates
```sh
/scripts/extractDeploy.sh deploy templates
```
In terms of settings this operation probably has more to do with `extract` than plain `deploy` since it interacts with Web Modeler rather than Zeebe.

The following is perhaps more of a specification than a description in so far as I haven't really had a proper opportunity to read what the code does as yet.

- Probably the root folder has a `config.[json|yaml]` much the same as for extract - since the repo that the templates are stored in is expected to support a single WM project
- Did we agree that we would use the name of the connector as a directory in which to store the actual template - I think we did. Otherwise we are likely to get name clashes with multiple instances of `element-template.json`
- Not sure that we finished the conversation about template metadata. We were talking about recording a mapping between the 'local' version of the template and the 'timestamp' version in the target project. In my mind that file should go into the connector directory. Not exactly sure where you got to with that