### PR TITLE
Add safe.directory for Bitbucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Extract and Deploy process models from Web Modeler
 ## Background
-Web Modeler does not currently have support for the extraction and deployment of resources (i.e. BPMN and DMN models and Forms) to different CI / CD platforms such as GitLab, GitHub and Bitbucket -
+Web Modeler does not currently have support for the extraction and deployment of resources (i.e. BPMN and DMN models and Forms) to different CI / CD platforms such as GitLab, Github and Bitbucket -
 this must be managed by the user through the [WM API](https://docs.camunda.io/docs/apis-tools/web-modeler-api/overview/).
 The Web Modeler currently only has
 * An option to deploy models directly to a Zeebe cluster (subject to the user having the right roles assigned)
-* A native GitHub integration to allow users to synch the models to a repository (again, subject to the user having the right roles assigned)
+* A native Github integration to allow users to synch the models to a repository (again, subject to the user having the right roles assigned)
 
 ## Solution
 This project provides solutions to:

--- a/scripts/extract.sh
+++ b/scripts/extract.sh
@@ -17,22 +17,6 @@ source $SCRIPT_DIR/functions.sh
 checkRequiredEnvVar CICD_ACCESS_TOKEN               "$CICD_ACCESS_TOKEN"
 checkRequiredEnvVar CICD_REPOSITORY_PATH            "$CICD_REPOSITORY_PATH"
 
-if [ "$CICD_PLATFORM" = "" ]; then
-  CICD_PLATFORM=gitlab
-  if [ -z "$CICD_SERVER_HOST" ]; then
-    CICD_SERVER_HOST="gitlab.com"
-  fi
-elif [ "$CICD_PLATFORM" = "github" ]; then
-  if [ -z "$CICD_SERVER_HOST" ]; then
-    CICD_SERVER_HOST="github.com"
-  fi
-elif [ "$CICD_PLATFORM" = "bitbucket" ]; then
-  if [ -z "$CICD_SERVER_HOST" ]; then
-    CICD_SERVER_HOST="bitbucket.org"
-  fi
-fi
-echo "The CI/CD platform is: $CICD_PLATFORM"
-
 git config --global user.name "$GIT_USERNAME"
 git config --global user.email $GIT_USER_EMAIL
 

--- a/scripts/extractDeploy.sh
+++ b/scripts/extractDeploy.sh
@@ -51,8 +51,9 @@ elif [ "$CICD_PLATFORM" = "bitbucket" ]; then
     CICD_SERVER_HOST="bitbucket.org"
 
     # See https://community.atlassian.com/t5/Bitbucket-questions/Bitbucket-Pipelines-dubious-ownership-error/qaq-p/2189169
-    #It is believed that we are seeing this because we changed the default user in the docker image from root to bp3user
+    # Allow for user mismatch between the repo owner (root) and our docker user (bp3user)
     # Not clear yet whether this issue may also impact other platforms
+    # Updating global config ensures that the changes are only made in this environment and not to the repo itself
     git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
   fi
 fi

--- a/scripts/extractDeploy.sh
+++ b/scripts/extractDeploy.sh
@@ -37,6 +37,27 @@ case "$1" in
         ;;
 esac
 
+if [ "$CICD_PLATFORM" = "" ]; then
+  CICD_PLATFORM=gitlab
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="gitlab.com"
+  fi
+elif [ "$CICD_PLATFORM" = "github" ]; then
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="github.com"
+  fi
+elif [ "$CICD_PLATFORM" = "bitbucket" ]; then
+  if [ -z "$CICD_SERVER_HOST" ]; then
+    CICD_SERVER_HOST="bitbucket.org"
+
+    # See https://community.atlassian.com/t5/Bitbucket-questions/Bitbucket-Pipelines-dubious-ownership-error/qaq-p/2189169
+    #It is believed that we are seeing this because we changed the default user in the docker image from root to bp3user
+    # Not clear yet whether this issue may also impact other platforms
+    git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
+  fi
+fi
+echo "The CI/CD platform is: $CICD_PLATFORM"
+
 if [ $mode_extract == 1 ]; then
   echo "mode = 'extract'"
 #  checkRequiredEnvVar CAMUNDA_WM_CLIENT_ID          "$CAMUNDA_WM_CLIENT_ID"


### PR DESCRIPTION
City Fibre have just tried to run `extract` for the first time in a while (different image from previous successful runs) and it is failing. The error says
```
fatal: detected dubious ownership in repository at '/opt/atlassian/pipelines/agent/build'
To add an exception for this directory, call:
	git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
```
When I googled this error I found the following article - https://community.atlassian.com/t5/Bitbucket-questions/Bitbucket-Pipelines-dubious-ownership-error/qaq-p/2189169.
That makes complete sense to me as we only relatively recently changed WMED so that is runs as `bp3user` rather than `root`. It looks like we can overcome the problem by adding a
```
git config --global --add safe.directory /opt/atlassian/pipelines/agent/build
```
command somewhere. 