### PR TITLE
Added info logging to show the size of the resources being deployed

### DIFF
--- a/integration-tests/tests/deploy-1.sh
+++ b/integration-tests/tests/deploy-1.sh
@@ -77,6 +77,7 @@ When () {
     -e NO_GIT=true \
     -e CLUSTER_HOST=localhost \
     -e MODEL_PATH=./deploy-files \
+    -e LOG_LEVEL=DEBUG \
       --entrypoint /bin/sh $IMAGE_NAME:$IMAGE_REF
 
   echo Sleep for a few seconds whilst docker container comes up ...

--- a/integration-tests/tests/deploy-when-model-path-set-to-default.sh
+++ b/integration-tests/tests/deploy-when-model-path-set-to-default.sh
@@ -76,6 +76,7 @@ When () {
   docker run -d $DOCKER_TTY_OPTS --name wmed --net=host -w /local \
     -e NO_GIT=true \
     -e CLUSTER_HOST=localhost \
+    -e LOG_LEVEL=DEBUG \
       --entrypoint /bin/sh $IMAGE_NAME:$IMAGE_REF
 
   echo Sleep for a few seconds whilst docker container comes up ...

--- a/integration-tests/tests/extract-1.sh
+++ b/integration-tests/tests/extract-1.sh
@@ -105,6 +105,7 @@ When () {
     -e OAUTH2_TOKEN_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token \
     -e CAMUNDA_WM_PROJECT="$project_id" \
     -e CAMUNDA_WM_HOST="localhost:8070" \
+    -e LOG_LEVEL=DEBUG
       --entrypoint /bin/sh $IMAGE_NAME:$IMAGE_REF
 
   echo Sleep for a few seconds whilst docker container comes up ...

--- a/integration-tests/tests/extract-1.sh
+++ b/integration-tests/tests/extract-1.sh
@@ -105,7 +105,7 @@ When () {
     -e OAUTH2_TOKEN_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token \
     -e CAMUNDA_WM_PROJECT="$project_id" \
     -e CAMUNDA_WM_HOST="localhost:8070" \
-    -e LOG_LEVEL=DEBUG
+    -e LOG_LEVEL=DEBUG \
       --entrypoint /bin/sh $IMAGE_NAME:$IMAGE_REF
 
   echo Sleep for a few seconds whilst docker container comes up ...

--- a/integration-tests/tests/extract-fails-when-model-path-set-to-root.sh
+++ b/integration-tests/tests/extract-fails-when-model-path-set-to-root.sh
@@ -82,6 +82,7 @@ When () {
     -e OAUTH2_TOKEN_URL=http://localhost:18080/auth/realms/camunda-platform/protocol/openid-connect/token \
     -e CAMUNDA_WM_PROJECT="$project_id" \
     -e CAMUNDA_WM_HOST="localhost:8070" \
+    -e LOG_LEVEL=DEBUG \
       --entrypoint /bin/sh $IMAGE_NAME:$IMAGE_REF
 
   echo Sleep for a few seconds whilst docker container comes up ...

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -89,6 +89,11 @@ class Deployment(ModelAction):
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
         self.logger.info("Deploying resources: %s" + (" to tenant %s".format(tenant_id) if tenant_id is not None else "") + "...", resource_file_paths)
 
+        total_resource_sizes = sum(self.get_resource_size(resource_file_path)
+                                   for resource_file_path in resource_file_paths)
+        self.logger.info("Total size of all the resources to be deployed is %s",
+                         humanize.naturalsize(total_resource_sizes, binary=True))
+
         if self.continue_on_error:
             for resource_file_path in resource_file_paths:
                 try:
@@ -97,11 +102,6 @@ class Deployment(ModelAction):
                     self.logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
-
-        total_resource_sizes = sum(self.get_resource_size(resource_file_path)
-                                   for resource_file_path in resource_file_paths)
-        self.logger.info("Total size of all the deployed resources is %s",
-                         humanize.naturalsize(total_resource_sizes, binary=True))
 
     def get_resource_size(self, resource_file_path):
         size = os.path.getsize(resource_file_path)

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -85,11 +85,17 @@ class Deployment(ModelAction):
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
         logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
         if self.continue_on_error:
+            total_resource_size = 0
             for resource_file_path in resource_file_paths:
+                resource_size = os.path.getsize(resource_file_path)
+                logger.info("Resource '%s' has a size of '%d'", resource_file_path, resource_size)
+                total_resource_size += resource_size
                 try:
                     await self.zeebe_client.deploy_resource(resource_file_path, tenant_id = tenant_id)
                 except Exception as x:
                     logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
+
+            logger.info("Total size of all the deployed resources is '%d'", total_resource_size)
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
 

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -87,7 +87,7 @@ class Deployment(ModelAction):
         self.zeebe_client = ZeebeClient(grpc_channel)
 
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
-        self.logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
+        self.logger.info("Deploying resources: %s" + (" to tenant %s".format(tenant_id) if tenant_id is not None else "") + "...", resource_file_paths)
 
         if self.continue_on_error:
             for resource_file_path in resource_file_paths:

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -84,20 +84,24 @@ class Deployment(ModelAction):
 
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
         logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
+
+        total_resource_sizes = sum(self.get_resource_size(resource_file_path) for resource_file_path in resource_file_paths)
+        logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
+
         if self.continue_on_error:
-            total_resource_size = 0
             for resource_file_path in resource_file_paths:
-                resource_size = os.path.getsize(resource_file_path)
-                logger.info("Resource '%s' has a size of '%d'", resource_file_path, resource_size)
-                total_resource_size += resource_size
                 try:
                     await self.zeebe_client.deploy_resource(resource_file_path, tenant_id = tenant_id)
                 except Exception as x:
                     logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
-
-            logger.info("Total size of all the deployed resources is '%d'", total_resource_size)
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
+
+    def get_resource_size(self, resource_file_path):
+        size = os.path.getsize(resource_file_path)
+        logger.info("Resource '%s' has a size of '%d' bytes", resource_file_path, size)
+
+        return size
 
     async def main(self):
         # Types we need to support, according to:

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -14,9 +14,9 @@ from argparse import _MutuallyExclusiveGroup
 import configargparse
 import asyncio
 import glob
-import os
 import humanize
-
+import os
+import logging
 from typing import List, cast
 from grpc.aio import AioRpcError
 from pyzeebe import (
@@ -29,7 +29,6 @@ from pyzeebe.errors import ZeebeGatewayUnavailableError, ProcessInvalidError
 
 from model_action import ModelAction
 from oauth import OAuth2
-from logger import get_logger
 
 class Deployment(ModelAction):
     logger = None
@@ -37,9 +36,9 @@ class Deployment(ModelAction):
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
 
-        self.logger = get_logger(type(self).__name__, self.log_level)
+        self.logger = logging.getLogger(type(self).__name__)
 
-        self.oauth = OAuth2(args, self.log_level)
+        self.oauth = OAuth2(args)
         if args.cluster_id is not None:
             self.cluster_id = args.cluster_id
             self.region = args.cluster_region

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -85,9 +85,6 @@ class Deployment(ModelAction):
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
         logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
 
-        total_resource_sizes = sum(self.get_resource_size(resource_file_path) for resource_file_path in resource_file_paths)
-        logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
-
         if self.continue_on_error:
             for resource_file_path in resource_file_paths:
                 try:
@@ -96,6 +93,9 @@ class Deployment(ModelAction):
                     logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
+
+        total_resource_sizes = sum(self.get_resource_size(resource_file_path) for resource_file_path in resource_file_paths)
+        logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
 
     def get_resource_size(self, resource_file_path):
         size = os.path.getsize(resource_file_path)

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -37,9 +37,9 @@ class Deployment(ModelAction):
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
 
-        self.logger = get_logger("Deploy", self.log_level)
+        self.logger = get_logger(type(self).__name__, self.log_level)
 
-        self.oauth = OAuth2(args)
+        self.oauth = OAuth2(args, self.log_level)
         if args.cluster_id is not None:
             self.cluster_id = args.cluster_id
             self.region = args.cluster_region

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -36,7 +36,6 @@ class Deployment(ModelAction):
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
 
-        print(self.log_level)
         self.logger = get_logger("Deploy", self.log_level)
 
         self.oauth = OAuth2(args)

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -15,7 +15,7 @@ import configargparse
 import asyncio
 import glob
 import os
-import logging
+
 from typing import List, cast
 from grpc.aio import AioRpcError
 from pyzeebe import (
@@ -28,13 +28,17 @@ from pyzeebe.errors import ZeebeGatewayUnavailableError, ProcessInvalidError
 
 from model_action import ModelAction
 from oauth import OAuth2
-
-logger = logging.getLogger()
+from logger import get_logger
 
 class Deployment(ModelAction):
+    logger = None
 
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
+
+        print(self.log_level)
+        self.logger = get_logger("Deploy", self.log_level)
+
         self.oauth = OAuth2(args)
         if args.cluster_id is not None:
             self.cluster_id = args.cluster_id
@@ -83,23 +87,23 @@ class Deployment(ModelAction):
         self.zeebe_client = ZeebeClient(grpc_channel)
 
     async def deploy(self, resource_file_paths: List[os.PathLike[str]], tenant_id: str = None) -> None:
-        logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
+        self.logger.info("Deploying resources: %s" + (" to tenant %s" if tenant_id is not None else "") + "...", resource_file_paths, tenant_id)
 
         if self.continue_on_error:
             for resource_file_path in resource_file_paths:
                 try:
                     await self.zeebe_client.deploy_resource(resource_file_path, tenant_id = tenant_id)
                 except Exception as x:
-                    logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
+                    self.logger.exception("*** FILE: %s COULD NOT BE DEPLOYED ***", resource_file_path)
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
 
         total_resource_sizes = sum(self.get_resource_size(resource_file_path) for resource_file_path in resource_file_paths)
-        logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
+        self.logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
 
     def get_resource_size(self, resource_file_path):
         size = os.path.getsize(resource_file_path)
-        logger.info("Resource '%s' has a size of '%d' bytes", resource_file_path, size)
+        self.logger.info("Resource '%s' has a size of '%d' bytes", resource_file_path, size)
 
         return size
 
@@ -111,10 +115,10 @@ class Deployment(ModelAction):
         for file_type in file_types:
             files.extend(glob.glob(f"{self.model_path}/**/{file_type}", recursive=True))
         if len(files) == 0:
-            logger.warning("Didn't find any files to deploy in '%s' matching %s.", self.model_path, file_types)
+            self.logger.warning("Didn't find any files to deploy in '%s' matching %s.", self.model_path, file_types)
             return
 
-        logger.debug("Found files: %s", files)
+        self.logger.debug("Found files: %s", files)
 
         self.create_zeebe_client()
         try:
@@ -125,10 +129,10 @@ class Deployment(ModelAction):
             else:
                 await self.deploy(files)
         except ZeebeGatewayUnavailableError as ex:
-            logger.error(ex.grpc_error)
+            self.logger.error(ex.grpc_error)
             exit(3)
         except ProcessInvalidError as ex:
-            logger.error(cast(AioRpcError, ex.__cause__)._details)
+            self.logger.error(cast(AioRpcError, ex.__cause__)._details)
             exit(3)
 
     @staticmethod

--- a/python/deploy.py
+++ b/python/deploy.py
@@ -15,6 +15,7 @@ import configargparse
 import asyncio
 import glob
 import os
+import humanize
 
 from typing import List, cast
 from grpc.aio import AioRpcError
@@ -97,12 +98,14 @@ class Deployment(ModelAction):
         else:
             await self.zeebe_client.deploy_resource(*resource_file_paths, tenant_id = tenant_id)
 
-        total_resource_sizes = sum(self.get_resource_size(resource_file_path) for resource_file_path in resource_file_paths)
-        self.logger.info("Total size of all the deployed resources is '%d' bytes", total_resource_sizes)
+        total_resource_sizes = sum(self.get_resource_size(resource_file_path)
+                                   for resource_file_path in resource_file_paths)
+        self.logger.info("Total size of all the deployed resources is %s",
+                         humanize.naturalsize(total_resource_sizes, binary=True))
 
     def get_resource_size(self, resource_file_path):
         size = os.path.getsize(resource_file_path)
-        self.logger.info("Resource '%s' has a size of '%d' bytes", resource_file_path, size)
+        self.logger.info("Resource '%s' has a size of %s", resource_file_path, humanize.naturalsize(size, binary=True))
 
         return size
 

--- a/python/deploy_connector_templates.py
+++ b/python/deploy_connector_templates.py
@@ -9,16 +9,14 @@
 # the laws of the United States and other countries.
 #
 ############################################################################
-import logging
-
 import configargparse
 import glob
 import json
+import logging
 
 from model_action import ModelAction
 from web_modeler import WebModeler, NotFoundError, MultipleFoundError
 from oauth import AuthenticationError
-from logger import get_logger
 
 class DeployTemplates(ModelAction):
     logger = None
@@ -26,9 +24,9 @@ class DeployTemplates(ModelAction):
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
 
-        self.logger = get_logger(type(self).__name__, self.log_level)
+        self.logger = logging.getLogger(type(self).__name__)
 
-        self.wm = WebModeler(args, self.log_level)
+        self.wm = WebModeler(args)
 
     def deploy_template(self, template_path: str, project_id: str):
         self.logger.info("Processing template %s", template_path)
@@ -111,5 +109,5 @@ if __name__ == "__main__":
     try:
         DeployTemplates(args).main(args)
     except (AuthenticationError, NotFoundError, MultipleFoundError) as ex:
-        get_logger("DeployTemplates.main", logging.ERROR).error(ex)
+        logging.getLogger("DeployTemplates.main").error(ex)
         exit(3)

--- a/python/deploy_connector_templates.py
+++ b/python/deploy_connector_templates.py
@@ -9,24 +9,29 @@
 # the laws of the United States and other countries.
 #
 ############################################################################
+import logging
+
 import configargparse
 import glob
 import json
-import logging
 
 from model_action import ModelAction
 from web_modeler import WebModeler, NotFoundError, MultipleFoundError
 from oauth import AuthenticationError
-
-logger = logging.getLogger()
+from logger import get_logger
 
 class DeployTemplates(ModelAction):
+    logger = None
+
     def __init__(self, args: configargparse.Namespace):
         super().__init__(args)
-        self.wm = WebModeler(args)
+
+        self.logger = get_logger(type(self).__name__, self.log_level)
+
+        self.wm = WebModeler(args, self.log_level)
 
     def deploy_template(self, template_path: str, project_id: str):
-        logger.info("Processing template %s", template_path)
+        self.logger.info("Processing template %s", template_path)
         with open(template_path, 'r') as file:
             content = json.load(file)
             source_version = content["version"]
@@ -54,7 +59,7 @@ class DeployTemplates(ModelAction):
                         revision = files["items"][0]["revision"]
                     )
                 else:
-                    logger.info("\tNo changes to the template, skipping it.")
+                    self.logger.info("\tNo changes to the template, skipping it.")
             else:
                 try:
                     response = self.wm.post_file(
@@ -66,7 +71,7 @@ class DeployTemplates(ModelAction):
                     if response is not None:
                         file_id = response["id"]
                 except RuntimeError as error:
-                    logger.exception("\tError processing template %s", template_path)
+                    self.logger.exception("\tError processing template %s", template_path)
                     return
 
             if response is not None:
@@ -75,22 +80,22 @@ class DeployTemplates(ModelAction):
                     name = source_version
                 )
                 if milestone_response is not None:
-                    logger.info("Created milestone %s", milestone_response["name"])
+                    self.logger.info("Created milestone %s", milestone_response["name"])
 
     def main(self, args: configargparse.Namespace):
         templates = glob.glob(f"{self.model_path}/**/element-templates/*.json", recursive = True)
         if len(templates) == 0:
-            logger.warning("No templates to deploy.")
+            self.logger.warning("No templates to deploy.")
             return
 
-        logger.debug("Found templates: %s", templates)
+        self.logger.debug("Found templates: %s", templates)
 
         try:
             self.wm.authenticate()
 
             project_id = self.wm.get_project(args.project)["id"]
         except ValueError as error:
-            logger.error(error)
+            self.logger.error(error)
             parser.print_usage()
             exit(2)
 
@@ -106,5 +111,5 @@ if __name__ == "__main__":
     try:
         DeployTemplates(args).main(args)
     except (AuthenticationError, NotFoundError, MultipleFoundError) as ex:
-        logger.error(ex)
+        get_logger("DeployTemplates.main", logging.ERROR).error(ex)
         exit(3)

--- a/python/extract.py
+++ b/python/extract.py
@@ -26,7 +26,7 @@ class Extraction(ModelAction):
 
         self.logger = get_logger(type(self).__name__, self.log_level)
 
-        self.wm = WebModeler(args)
+        self.wm = WebModeler(args, self.log_level)
         if args.exclude is not None:
             self.self.logger.info("Excluding paths with segments that match %s", args.exclude)
             self.exclude_pattern = re.compile(args.exclude)

--- a/python/extract.py
+++ b/python/extract.py
@@ -9,14 +9,13 @@
 # the laws of the United States and other countries.
 #
 ############################################################################
-import logging
 import configargparse
+import logging
 import os
 import re
 from model_action import ModelAction
 from web_modeler import WebModeler, NotFoundError, MultipleFoundError
 from oauth import AuthenticationError
-from logger import get_logger
 
 class Extraction(ModelAction):
     logger = None
@@ -24,9 +23,9 @@ class Extraction(ModelAction):
     def __init__(self, args):
         super().__init__(args)
 
-        self.logger = get_logger(type(self).__name__, self.log_level)
+        self.logger = logging.getLogger(type(self).__name__)
 
-        self.wm = WebModeler(args, self.log_level)
+        self.wm = WebModeler(args)
         if args.exclude is not None:
             self.logger.info("Excluding paths with segments that match %s", args.exclude)
             self.exclude_pattern = re.compile(args.exclude)
@@ -80,5 +79,5 @@ if __name__ == "__main__":
     try:
         Extraction(args).main()
     except (AuthenticationError, NotFoundError, MultipleFoundError) as ex:
-        get_logger("Extraction.main", logging.ERROR).error(ex)
+        logging.getLogger("Extraction.main").error(ex)
         exit(3)

--- a/python/extract.py
+++ b/python/extract.py
@@ -28,7 +28,7 @@ class Extraction(ModelAction):
 
         self.wm = WebModeler(args, self.log_level)
         if args.exclude is not None:
-            self.self.logger.info("Excluding paths with segments that match %s", args.exclude)
+            self.logger.info("Excluding paths with segments that match %s", args.exclude)
             self.exclude_pattern = re.compile(args.exclude)
         else:
             self.exclude_pattern = None

--- a/python/extract.py
+++ b/python/extract.py
@@ -9,23 +9,26 @@
 # the laws of the United States and other countries.
 #
 ############################################################################
-import configargparse
 import logging
+import configargparse
 import os
 import re
 from model_action import ModelAction
 from web_modeler import WebModeler, NotFoundError, MultipleFoundError
 from oauth import AuthenticationError
-
-logger = logging.getLogger()
+from logger import get_logger
 
 class Extraction(ModelAction):
+    logger = None
 
     def __init__(self, args):
         super().__init__(args)
+
+        self.logger = get_logger(type(self).__name__, self.log_level)
+
         self.wm = WebModeler(args)
         if args.exclude is not None:
-            logger.info("Excluding paths with segments that match %s", args.exclude)
+            self.self.logger.info("Excluding paths with segments that match %s", args.exclude)
             self.exclude_pattern = re.compile(args.exclude)
         else:
             self.exclude_pattern = None
@@ -46,7 +49,7 @@ class Extraction(ModelAction):
                         break
 
             if included:
-                logger.info("Extracting item to %s", file_path)
+                self.logger.info("Extracting item to %s", file_path)
                 if item["canonicalPath"] is not None and item["canonicalPath"]:
                     os.makedirs(os.path.dirname(file_path), exist_ok = True)
 
@@ -60,7 +63,7 @@ class Extraction(ModelAction):
 
             project_id = self.wm.get_project(args.project)["id"]
         except ValueError as error:
-            logger.error(error)
+            self.logger.error(error)
             parser.print_usage()
             exit(2)
         project_items = self.wm.list_files(project_id)
@@ -77,5 +80,5 @@ if __name__ == "__main__":
     try:
         Extraction(args).main()
     except (AuthenticationError, NotFoundError, MultipleFoundError) as ex:
-        logger.error(ex)
+        get_logger("Extraction.main", logging.ERROR).error(ex)
         exit(3)

--- a/python/logger.py
+++ b/python/logger.py
@@ -1,0 +1,9 @@
+import logging
+import sys
+
+
+def get_logger(name, level):
+    logger = logging.getLogger(name)
+    logging.basicConfig(stream=sys.stdout, level=level)
+
+    return logger

--- a/python/logger.py
+++ b/python/logger.py
@@ -1,9 +1,0 @@
-import logging
-import sys
-
-
-def get_logger(name, level):
-    logger = logging.getLogger(name)
-    logging.basicConfig(stream=sys.stdout, level=level)
-
-    return logger

--- a/python/model_action.py
+++ b/python/model_action.py
@@ -14,7 +14,7 @@ import configargparse
 class ModelAction:
     parser = configargparse.ArgumentParser(add_help = False)
     parser.add_argument("--model-path", dest="model_path", help = "Model file path", env_var = "MODEL_PATH", default=".")
-    parser.add_argument("--log-level", dest="log_level", help = "Log level", env_var = "LOG_LEVEL", default="INFO")
+    parser.add_argument("--log-level", dest="log_level", help = "Log level", env_var = "LOG_LEVEL", default="ERROR")
 
     def __init__(self, args):
         super().__init__()

--- a/python/model_action.py
+++ b/python/model_action.py
@@ -10,13 +10,16 @@
 #
 ############################################################################
 import configargparse
+import logging
+import sys
 
 class ModelAction:
     parser = configargparse.ArgumentParser(add_help = False)
+    parser.add_argument("--log-level", dest="log_level", help = "Log level", env_var = "LOG_LEVEL", default = "ERROR",
+                        choices = ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"], nargs = "?")
     parser.add_argument("--model-path", dest="model_path", help = "Model file path", env_var = "MODEL_PATH", default=".")
-    parser.add_argument("--log-level", dest="log_level", help = "Log level (CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET)", env_var = "LOG_LEVEL", default="ERROR")
 
     def __init__(self, args):
         super().__init__()
         self.model_path = args.model_path
-        self.log_level = args.log_level
+        logging.basicConfig(stream=sys.stdout, level=args.log_level.upper())

--- a/python/model_action.py
+++ b/python/model_action.py
@@ -14,7 +14,9 @@ import configargparse
 class ModelAction:
     parser = configargparse.ArgumentParser(add_help = False)
     parser.add_argument("--model-path", dest="model_path", help = "Model file path", env_var = "MODEL_PATH", default=".")
+    parser.add_argument("--log-level", dest="log_level", help = "Log level", env_var = "LOG_LEVEL", default="INFO")
 
     def __init__(self, args):
         super().__init__()
         self.model_path = args.model_path
+        self.log_level = args.log_level

--- a/python/model_action.py
+++ b/python/model_action.py
@@ -14,7 +14,7 @@ import configargparse
 class ModelAction:
     parser = configargparse.ArgumentParser(add_help = False)
     parser.add_argument("--model-path", dest="model_path", help = "Model file path", env_var = "MODEL_PATH", default=".")
-    parser.add_argument("--log-level", dest="log_level", help = "Log level", env_var = "LOG_LEVEL", default="ERROR")
+    parser.add_argument("--log-level", dest="log_level", help = "Log level (CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET)", env_var = "LOG_LEVEL", default="ERROR")
 
     def __init__(self, args):
         super().__init__()

--- a/python/oauth.py
+++ b/python/oauth.py
@@ -13,10 +13,10 @@ import os
 from argparse import _MutuallyExclusiveGroup
 
 import configargparse
+import logging
 import requests
 from oauthlib.oauth2 import BackendApplicationClient, OAuth2Error
 from requests_oauthlib import OAuth2Session
-from logger import get_logger
 
 class AuthenticationError(Exception):
     def __init__(self, status_code = None, response_text = None):
@@ -56,10 +56,10 @@ class OAuth2:
                         env_var = "OAUTH2_SCOPE")
     add_deprecated_options(client_id_group, client_secret_group)
 
-    def __init__(self, args, log_level):
+    def __init__(self, args):
         super().__init__()
 
-        self.logger = get_logger(type(self).__name__, log_level)
+        self.logger = logging.getLogger(type(self).__name__)
 
         self.token_url = args.token_url
         self.audience = args.audience
@@ -94,5 +94,5 @@ class OAuth2:
             self.logger.exception("Error while authenticating")
             exit(3)
         except requests.exceptions.ConnectionError as ex:
-            self.logger.exception("Error while retrieving OAuth token")
+            self.logger.error(f"Error while retrieving OAuth token {ex}")
             exit(3)

--- a/python/oauth.py
+++ b/python/oauth.py
@@ -13,12 +13,10 @@ import os
 from argparse import _MutuallyExclusiveGroup
 
 import configargparse
-import logging
 import requests
 from oauthlib.oauth2 import BackendApplicationClient, OAuth2Error
 from requests_oauthlib import OAuth2Session
-
-logger = logging.getLogger()
+from logger import get_logger
 
 class AuthenticationError(Exception):
     def __init__(self, status_code = None, response_text = None):
@@ -28,6 +26,8 @@ class AuthenticationError(Exception):
 
 
 class OAuth2:
+    logger = None
+
     @staticmethod
     def add_deprecated_options(client_id_group: _MutuallyExclusiveGroup, client_secret_group: _MutuallyExclusiveGroup):
         client_id_group.add_argument("--camunda-wm-client-id", dest="client_id", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth2-client-id instead",
@@ -56,8 +56,11 @@ class OAuth2:
                         env_var = "OAUTH2_SCOPE")
     add_deprecated_options(client_id_group, client_secret_group)
 
-    def __init__(self, args):
+    def __init__(self, args, log_level):
         super().__init__()
+
+        self.logger = get_logger(type(self).__name__, log_level)
+
         self.token_url = args.token_url
         self.audience = args.audience
         self.grant_type = args.grant_type
@@ -88,8 +91,8 @@ class OAuth2:
                                                     client_secret=self.client_secret,
                                                     kwargs=data)["access_token"]
         except OAuth2Error as ex:
-            logger.exception("Error while authenticating")
+            self.logger.exception("Error while authenticating")
             exit(3)
         except requests.exceptions.ConnectionError as ex:
-            logger.exception("Error while retrieving OAuth token")
+            self.logger.exception("Error while retrieving OAuth token")
             exit(3)

--- a/python/oauth.py
+++ b/python/oauth.py
@@ -30,13 +30,13 @@ class AuthenticationError(Exception):
 class OAuth2:
     @staticmethod
     def add_deprecated_options(client_id_group: _MutuallyExclusiveGroup, client_secret_group: _MutuallyExclusiveGroup):
-        client_id_group.add_argument("--camunda-wm-client-id", dest="client_id", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth-client-id instead",
+        client_id_group.add_argument("--camunda-wm-client-id", dest="client_id", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth2-client-id instead",
                                      env_var = "CAMUNDA_WM_CLIENT_ID", deprecated = True)
-        client_id_group.add_argument("--zeebe-client-id", dest="client_id", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth-client-id instead",
+        client_id_group.add_argument("--zeebe-client-id", dest="client_id", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth2-client-id instead",
                                      env_var = "ZEEBE_CLIENT_ID", deprecated = True)
-        client_secret_group.add_argument("--camunda-wm-client-secret", dest="client_secret", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth-client-secret instead",
+        client_secret_group.add_argument("--camunda-wm-client-secret", dest="client_secret", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth2-client-secret instead",
                                          env_var = "CAMUNDA_WM_CLIENT_SECRET", deprecated = True)
-        client_secret_group.add_argument("--zeebe-client-secret", dest="client_secret", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth-client-secret instead",
+        client_secret_group.add_argument("--zeebe-client-secret", dest="client_secret", help = configargparse.SUPPRESS, #"Deprecated: Use --oauth2-client-secret instead",
                                          env_var = "ZEEBE_CLIENT_SECRET", deprecated = True)
 
     parser = configargparse.ArgumentParser(add_help = False)

--- a/python/web_modeler.py
+++ b/python/web_modeler.py
@@ -52,7 +52,7 @@ class WebModeler:
 
         self.logger = get_logger(type(self).__name__, log_level)
 
-        self.oauth = OAuth2(args)
+        self.oauth = OAuth2(args, log_level)
 
         # TODO replace this with web modeler url
         # Current options require port to be specified with the host which is not intuitive

--- a/python/web_modeler.py
+++ b/python/web_modeler.py
@@ -16,7 +16,6 @@ import os
 import json
 import yaml
 from oauth import OAuth2
-from logger import get_logger
 
 class NotFoundError(Exception):
     def __init__(self, resource_type: str, key: str = None, value: str = None):
@@ -47,12 +46,12 @@ class WebModeler:
                         env_var="OAUTH_PLATFORM", choices=['KEYCLOAK', 'ENTRA'], default='KEYCLOAK', deprecated = True )
 
 
-    def __init__(self, args: configargparse.Namespace, log_level):
+    def __init__(self, args: configargparse.Namespace):
         super().__init__()
 
-        self.logger = get_logger(type(self).__name__, log_level)
+        self.logger = logging.getLogger(type(self).__name__)
 
-        self.oauth = OAuth2(args, log_level)
+        self.oauth = OAuth2(args)
 
         # TODO replace this with web modeler url
         # Current options require port to be specified with the host which is not intuitive

--- a/python/web_modeler.py
+++ b/python/web_modeler.py
@@ -16,8 +16,7 @@ import os
 import json
 import yaml
 from oauth import OAuth2
-
-logger = logging.getLogger()
+from logger import get_logger
 
 class NotFoundError(Exception):
     def __init__(self, resource_type: str, key: str = None, value: str = None):
@@ -35,6 +34,8 @@ class MultipleFoundError(Exception):
 class WebModeler:
     __SAAS_HOST: str = 'modeler.cloud.camunda.io'
 
+    logger = None
+
     parser = configargparse.ArgumentParser(parents=[OAuth2.parser], add_help=False)
     parser.add_argument("--host", help="Web Modeler host",
                         env_var="CAMUNDA_WM_HOST", default='modeler.cloud.camunda.io')
@@ -46,8 +47,11 @@ class WebModeler:
                         env_var="OAUTH_PLATFORM", choices=['KEYCLOAK', 'ENTRA'], default='KEYCLOAK', deprecated = True )
 
 
-    def __init__(self, args: configargparse.Namespace):
+    def __init__(self, args: configargparse.Namespace, log_level):
         super().__init__()
+
+        self.logger = get_logger(type(self).__name__, log_level)
+
         self.oauth = OAuth2(args)
 
         # TODO replace this with web modeler url
@@ -103,7 +107,7 @@ class WebModeler:
                 },
                 headers=headers
             )
-            logger.debug("Find project response %s", response.status_code)
+            self.logger.debug("Find project response %s", response.status_code)
             if response.status_code == 404:
                 raise NotFoundError("Project", key, value)
             elif response.status_code == 401:
@@ -112,7 +116,7 @@ class WebModeler:
                 raise RuntimeError("Find project failed:", response.status_code, response.text)
             return response.json()
         except requests.exceptions.ConnectionError as ex:
-            logger.exception("Error while finding project")
+            self.logger.exception("Error while finding project")
             exit(3)
 
     def list_files(self, project_id: str, name: str = None) -> dict:
@@ -161,7 +165,7 @@ class WebModeler:
             self.__wm_api_url + "/files/" + file_id,
             headers = self.__get_headers()
         )
-        logger.debug("Retrieve file content response %s", response.status_code)
+        self.logger.debug("Retrieve file content response %s", response.status_code)
         return response.json()
 
     def __create_config_file(self, data: dict):
@@ -185,7 +189,7 @@ class WebModeler:
                     self.__config = yaml.safe_load(file)
                 elif self.config_file.endswith("json"):
                     self.__config = json.load(file)
-                logger.info("Loaded config %s from %s", self.__config, self.config_file)
+                self.logger.info("Loaded config %s from %s", self.__config, self.config_file)
 
     def get_project(self, project_ref: str) -> dict:
         projects = None
@@ -196,7 +200,7 @@ class WebModeler:
         if self.__config is not None:
             project_ = self.__config["project"]
             if project_ref is not None and project_ref != project_["name"]:
-                logger.info("The project '%s' does not match the project '%s' from %s, ignoring contents and regenerating.",
+                self.logger.info("The project '%s' does not match the project '%s' from %s, ignoring contents and regenerating.",
                             project_ref, project_["name"], self.config_file)
                 self.__delete_config_file()
                 projects = None
@@ -204,16 +208,16 @@ class WebModeler:
                 project_id = project_["id"]
                 projects = self.find_project("id", project_id)
                 if projects is None:
-                    logger.warning("Project not found using project ID %s from %s", project_id, self.config_file)
+                    self.logger.warning("Project not found using project ID %s from %s", project_id, self.config_file)
                 elif not projects['items']:
-                    logger.warning("Project not found using project ID %s from %s", project_id, self.config_file)
+                    self.logger.warning("Project not found using project ID %s from %s", project_id, self.config_file)
                     projects = None
 
         # If we failed to find the specified project, or no config was supplied, then try looking it up by project_ref
         if projects is None:
             create_config_file = True
             # First, try by id
-            logger.debug("project_ref = '%s'", project_ref)
+            self.logger.debug("project_ref = '%s'", project_ref)
             if project_ref is not None and project_ref != "":
                 projects = self.find_project("id", project_ref)
                 # Then try by name
@@ -272,7 +276,7 @@ class WebModeler:
             headers = self.__get_headers()
         )
 
-        logger.info("Update file response %s", response.status_code)
+        self.logger.info("Update file response %s", response.status_code)
         if response.status_code != 200:
             raise RuntimeError("Attempt to update file failed.", response.json())
         return response.json()
@@ -287,7 +291,7 @@ class WebModeler:
             headers = self.__get_headers()
         )
 
-        logger.info("Create milestone response %s", response.status_code)
+        self.logger.info("Create milestone response %s", response.status_code)
         if response.status_code != 200:
             raise RuntimeError("Attempt to create milestone failed.", response.json())
         return response.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pyzeebe >= 4.5.0
 ConfigArgParse
 requests
 pyyaml
+humanize


### PR DESCRIPTION
This change is to write out to the logs the size of the individual resources being deployed as well as the total size of all the deployed resources. This is so if we have the situation where the max message size is reached and the deployment fails, we can at least see what the offending resources are likely to be (e.g. someone has stuck a load of documentation into a model).

```
INFO:Deployment:Resource './deploy-files/process.bpmn' has a size of 5.4 KiB
INFO:Deployment:Resource './deploy-files/process2.bpmn' has a size of 2.7 KiB
INFO:Deployment:Total size of all the resources to be deployed is 8.1 KiB
```

Further changes are to allow the log level to be changed by passing it in as an environment variable in the Docker run command, for example:

```
-e LOG_LEVEL=DEBUG
```

The possible values are `CRITICAL`, `ERROR`, `WARNING`, `INFO`, `DEBUG` or `NOTSET` (taken from here: https://docs.python.org/3/library/logging.html#logging-levels).

Examples of logging can be found in the unit test pipelines here:
- Extract: https://github.com/BP3/wm-extract-deploy/actions/runs/19473994488/job/55728877775#step:7:434
- Deploy: https://github.com/BP3/wm-extract-deploy/actions/runs/19473994488/job/55728877775#step:8:65
